### PR TITLE
Fix masked softmax in inference

### DIFF
--- a/maia2/inference.py
+++ b/maia2/inference.py
@@ -1,6 +1,19 @@
 from .utils import *
 from .main import *
 
+
+def _masked_softmax(logits, legal_moves):
+
+    legal_moves = legal_moves.bool()
+    rows_without_legal_moves = ~legal_moves.any(dim=-1)
+    if rows_without_legal_moves.any():
+        row_indices = rows_without_legal_moves.nonzero(as_tuple=False).flatten().tolist()
+        raise ValueError(f"Cannot run inference without legal moves (batch rows: {row_indices}).")
+
+    masked_logits = logits.masked_fill(~legal_moves, float("-inf"))
+    return masked_logits.softmax(dim=-1)
+
+
 def preprocessing(fen, elo_self, elo_oppo, elo_dict, all_moves_dict):
         
     if fen.split(' ')[1] == 'w':
@@ -16,7 +29,10 @@ def preprocessing(fen, elo_self, elo_oppo, elo_dict, all_moves_dict):
     elo_oppo = map_to_category(elo_oppo, elo_dict)
     
     legal_moves = torch.zeros(len(all_moves_dict))
-    legal_moves_idx = torch.tensor([all_moves_dict[move.uci()] for move in board.legal_moves])
+    legal_moves_idx = [all_moves_dict[move.uci()] for move in board.legal_moves]
+    if not legal_moves_idx:
+        raise ValueError(f"Cannot run inference on a position without legal moves: {fen}")
+    legal_moves_idx = torch.tensor(legal_moves_idx, dtype=torch.long)
     legal_moves[legal_moves_idx] = 1
     
     return board_input, elo_self, elo_oppo, legal_moves
@@ -60,13 +76,7 @@ def get_preds(model, dataloader, all_moves_dict_reversed):
             legal_moves = legal_moves.to(device)
 
             logits_maia, _, logits_value = model(boards, elos_self, elos_oppo)
-            if not legal_moves.any(dim=-1).all():
-                # no legal moves available, so just output zeros for all probabilities
-                # this should prevent any moves from being present in the output dictionary
-                probs = torch.zeros_like(logits_maia, device='cpu').tolist()
-            else:
-                logits_maia_legal = logits_maia + legal_moves.log()
-                probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
+            probs = _masked_softmax(logits_maia, legal_moves).cpu().tolist()
             
             logits_value = (logits_value / 2 + 0.5).clamp(0, 1).cpu().tolist()
         
@@ -160,13 +170,7 @@ def inference_each(model, prepared, fen, elo_self, elo_oppo):
     
     logits_maia, _, logits_value = model(board_input, elo_self, elo_oppo)
 
-    if not legal_moves.any(dim=-1).all():
-        # no legal moves available, so just output zeros for all probabilities
-        # this should prevent any moves from being present in the output dictionary
-        probs = torch.zeros_like(logits_maia, device='cpu').tolist()
-    else:
-        logits_maia_legal = logits_maia + legal_moves.log()
-        probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
+    probs = _masked_softmax(logits_maia, legal_moves).cpu().tolist()
     
     logits_value = (logits_value / 2 + 0.5).clamp(0, 1).item()
     
@@ -191,4 +195,3 @@ def inference_each(model, prepared, fen, elo_self, elo_oppo):
     move_probs = dict(sorted(move_probs.items(), key=lambda item: item[1], reverse=True))
     
     return move_probs, win_prob
-

--- a/maia2/inference.py
+++ b/maia2/inference.py
@@ -154,7 +154,7 @@ def inference_each(model, prepared, fen, elo_self, elo_oppo):
     legal_moves = legal_moves.unsqueeze(dim=0).to(device)
     
     logits_maia, _, logits_value = model(board_input, elo_self, elo_oppo)
-    logits_maia_legal = logits_maia * legal_moves
+    logits_maia_legal = logits_maia + legal_moves.log()
     probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
     
     logits_value = (logits_value / 2 + 0.5).clamp(0, 1).item()

--- a/maia2/inference.py
+++ b/maia2/inference.py
@@ -60,7 +60,7 @@ def get_preds(model, dataloader, all_moves_dict_reversed):
             legal_moves = legal_moves.to(device)
 
             logits_maia, _, logits_value = model(boards, elos_self, elos_oppo)
-            logits_maia_legal = logits_maia * legal_moves
+            logits_maia_legal = logits_maia + legal_moves.log()
             probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
             
             logits_value = (logits_value / 2 + 0.5).clamp(0, 1).cpu().tolist()

--- a/maia2/inference.py
+++ b/maia2/inference.py
@@ -60,8 +60,13 @@ def get_preds(model, dataloader, all_moves_dict_reversed):
             legal_moves = legal_moves.to(device)
 
             logits_maia, _, logits_value = model(boards, elos_self, elos_oppo)
-            logits_maia_legal = logits_maia + legal_moves.log()
-            probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
+            if not legal_moves.any(dim=-1).all():
+                # no legal moves available, so just output zeros for all probabilities
+                # this should prevent any moves from being present in the output dictionary
+                probs = torch.zeros_like(logits_maia, device='cpu').tolist()
+            else:
+                logits_maia_legal = logits_maia + legal_moves.log()
+                probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
             
             logits_value = (logits_value / 2 + 0.5).clamp(0, 1).cpu().tolist()
         
@@ -154,8 +159,14 @@ def inference_each(model, prepared, fen, elo_self, elo_oppo):
     legal_moves = legal_moves.unsqueeze(dim=0).to(device)
     
     logits_maia, _, logits_value = model(board_input, elo_self, elo_oppo)
-    logits_maia_legal = logits_maia + legal_moves.log()
-    probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
+
+    if not legal_moves.any(dim=-1).all():
+        # no legal moves available, so just output zeros for all probabilities
+        # this should prevent any moves from being present in the output dictionary
+        probs = torch.zeros_like(logits_maia, device='cpu').tolist()
+    else:
+        logits_maia_legal = logits_maia + legal_moves.log()
+        probs = logits_maia_legal.softmax(dim=-1).cpu().tolist()
     
     logits_value = (logits_value / 2 + 0.5).clamp(0, 1).item()
     

--- a/tests/test_inference_masking.py
+++ b/tests/test_inference_masking.py
@@ -1,0 +1,72 @@
+import unittest
+
+import torch
+
+from maia2 import inference
+from maia2.utils import create_elo_dict, get_all_possible_moves
+
+
+NORMAL_FEN = "rn1q1rk1/ppp2ppp/4bn2/3p3P/4p3/P3P3/1PPPBPPb/RNBQK3 w Q - 0 11"
+TERMINAL_FEN = "7k/5Q2/7K/8/8/8/8/8 b - - 0 1"
+
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, move_count):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.move_count = move_count
+
+    def forward(self, boards, elos_self, elos_oppo):
+        batch_size = boards.shape[0]
+        logits = torch.linspace(-1, 1, self.move_count, device=boards.device)
+        logits = logits.unsqueeze(0).repeat(batch_size, 1) + self.anchor
+        value = torch.zeros(batch_size, device=boards.device) + self.anchor
+        return logits, None, value
+
+
+class MaskingRegressionTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.moves = get_all_possible_moves()
+        cls.move_to_index = {move: i for i, move in enumerate(cls.moves)}
+        cls.index_to_move = {i: move for move, i in cls.move_to_index.items()}
+        cls.elo_dict = create_elo_dict()
+        cls.model = DummyModel(len(cls.moves))
+
+    def test_masked_softmax_zeros_illegal_moves_and_normalizes_each_row(self):
+        logits = torch.tensor([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]])
+        legal_moves = torch.tensor([[1, 0, 1], [0, 1, 1]])
+
+        probs = inference._masked_softmax(logits, legal_moves)
+
+        self.assertEqual(probs[0, 1].item(), 0.0)
+        self.assertEqual(probs[1, 0].item(), 0.0)
+        torch.testing.assert_close(probs.sum(dim=-1), torch.ones(2))
+
+    def test_masked_softmax_rejects_only_the_empty_batch_rows(self):
+        logits = torch.zeros((2, 3))
+        legal_moves = torch.tensor([[1, 0, 1], [0, 0, 0]])
+
+        with self.assertRaisesRegex(ValueError, r"batch rows: \[1\]"):
+            inference._masked_softmax(logits, legal_moves)
+
+    def test_terminal_position_has_a_clear_error(self):
+        prepared = [self.move_to_index, self.elo_dict, self.index_to_move]
+
+        with self.assertRaisesRegex(ValueError, "position without legal moves"):
+            inference.inference_each(
+                self.model, prepared, TERMINAL_FEN, 1500, 1498
+            )
+
+    def test_normal_position_probabilities_sum_to_one(self):
+        prepared = [self.move_to_index, self.elo_dict, self.index_to_move]
+
+        move_probs, _ = inference.inference_each(
+            self.model, prepared, NORMAL_FEN, 1500, 1498
+        )
+
+        self.assertAlmostEqual(sum(move_probs.values()), 1.0, delta=0.005)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
During inference, logits corresponding to illegal moves are supposed to be masked out so that they have probability 0 after softmax. Right now, this is done by multiplying the logit with the legal moves mask before the softmax layer. However, the legal move mask is a set of 0s and 1s and the logits are in unnormalized log space. This means that multiplication by 0 just converts the logit to be 1 in unnormalized real space, so the invalid moves have non-zero probability after softmax. The correct way is to add `-inf` to all invalid logits so that they have probability 0 in real space.

See the following example:

```python
>>> x = torch.rand((3, 5)); x
tensor([[0.8924, 0.8796, 0.4099, 0.8877, 0.2908],
        [0.3853, 0.9005, 0.4000, 0.5488, 0.3874],
        [0.0757, 0.2595, 0.5019, 0.2247, 0.0422]])

>>> mask = torch.rand((3, 5)) > 0.6; mask
tensor([[False, False, False,  True, False],
        [ True,  True, False, False,  True],
        [False,  True, False,  True,  True]])

# without masking
>>> torch.softmax(x, dim = -1)
tensor([[0.2411, 0.2380, 0.1488, 0.2400, 0.1321],
        [0.1704, 0.2852, 0.1729, 0.2007, 0.1708],
        [0.1706, 0.2050, 0.2613, 0.1980, 0.1650]])

# current masking method; notice that everything is non-zero and invalid moves all have the same probability
>>> torch.softmax(x * mask, dim = -1)
tensor([[0.1555, 0.1555, 0.1555, 0.3779, 0.1555],
        [0.1986, 0.3324, 0.1351, 0.1351, 0.1990],
        [0.1789, 0.2318, 0.1789, 0.2239, 0.1866]])

# new masking method; masked out values are given 0 probability
>>> torch.softmax(x + mask.log(), dim = -1)
tensor([[0.0000, 0.0000, 0.0000, 1.0000, 0.0000],
        [0.2720, 0.4554, 0.0000, 0.0000, 0.2726],
        [0.0000, 0.3610, 0.0000, 0.3486, 0.2904]])
```