### PR TITLE
Link to Maia-3 from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Maia2: A Unified Model for Human-AI Alignment in Chess
 
+> [!IMPORTANT]
+> **[Maia-3](https://github.com/CSSLab/maia3) is now available and is recommended for new projects.** It is the latest generation of our human chess modeling work, built on the Chessformer architecture. See the [code](https://github.com/CSSLab/maia3), [pre-trained models](https://huggingface.co/collections/UofTCSSLab/maia3), [paper](https://arxiv.org/abs/2605.19091), and [website](https://maiachess.com/).
+
 The official implementation of the NeurIPS 2024 paper **Maia-2** [[paper](https://arxiv.org/abs/2409.20553)]. This work was led by [CSSLab](https://csslab.cs.toronto.edu/) at the University of Toronto.
 
 ## Abstract


### PR DESCRIPTION
## What changed

- Added a prominent Maia-3 notice at the top of the Maia2 README.
- Linked the Maia-3 code, pre-trained model collection, paper, and project website.

## Why

Maia-3 is the latest generation of the project and should be the starting point for new users, while the rest of the README remains available for Maia2 users.

## Validation

- `git diff --check`
- Verified each linked resource is currently available.
